### PR TITLE
Prevent accounts page directly opening in screen pinning mode

### DIFF
--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -534,6 +534,12 @@ public class SettingsActivity extends SettingsDrawerActivity
     @Override
     protected void onCreate(Bundle savedState) {
         super.onCreate(savedState);
+
+        if (isLockTaskModePinned() && !isSettingsRunOnTop()) {
+            Log.w(LOG_TAG, "Devices lock task mode pinned.");
+            finish();
+        }
+
         long startTime = System.currentTimeMillis();
 
         // Should happen before any call to getIntent()
@@ -1346,5 +1352,17 @@ public class SettingsActivity extends SettingsDrawerActivity
                     PackageManager.COMPONENT_ENABLED_STATE_DISABLED, PackageManager.DONT_KILL_APP);
         }
         super.onActivityResult(requestCode, resultCode, data);
+    }
+    private boolean isLockTaskModePinned() {
+        final ActivityManager activityManager =
+            getApplicationContext().getSystemService(ActivityManager.class);
+        return activityManager.getLockTaskModeState() == ActivityManager.LOCK_TASK_MODE_PINNED;
+    }
+    private boolean isSettingsRunOnTop() {
+        final ActivityManager activityManager =
+            getApplicationContext().getSystemService(ActivityManager.class);
+        final String taskPkgName = activityManager.getRunningTasks(1 /* maxNum */)
+            .get(0 /* index */).baseActivity.getPackageName();
+        return TextUtils.equals(getPackageName(), taskPkgName);
     }
 }


### PR DESCRIPTION
In Settings there is no auth mechanism to prevent accounts page being
opened in screen pinning mode. This CL makes it so that when users are
trying to navigate to any pages in Settings from other apps in screen
pinning mode, Settings app will directly close its page.

Bug: 137015265
Bug: 135604684
Test: manual
Change-Id: If26eda408a9ef6fa03ad82e5bee51bb7185950d6
Merged-In: If26eda408a9ef6fa03ad82e5bee51bb7185950d6
(cherry picked from commit f3242dab3546c019d4b79c502f7b8850d36123a5)
(cherry picked from commit ad2502a91a6d0814396b2d26a7270e8cbdb2ed38)