### PR TITLE
RESTRICT AUTOMERGE

### DIFF
--- a/src/com/android/settings/ConfirmDeviceCredentialBaseActivity.java
+++ b/src/com/android/settings/ConfirmDeviceCredentialBaseActivity.java
@@ -109,6 +109,11 @@ public abstract class ConfirmDeviceCredentialBaseActivity extends SettingsActivi
         }
     }
 
+    @Override
+    public boolean isLaunchableInTaskModePinned() {
+        return true;
+    }
+
     public void prepareEnterAnimation() {
         getFragment().prepareEnterAnimation();
     }

--- a/src/com/android/settings/SettingsActivity.java
+++ b/src/com/android/settings/SettingsActivity.java
@@ -535,7 +535,7 @@ public class SettingsActivity extends SettingsDrawerActivity
     protected void onCreate(Bundle savedState) {
         super.onCreate(savedState);
 
-        if (isLockTaskModePinned() && !isSettingsRunOnTop()) {
+        if (isLockTaskModePinned() && !isSettingsRunOnTop() && !isLaunchableInTaskModePinned()) {
             Log.w(LOG_TAG, "Devices lock task mode pinned.");
             finish();
         }
@@ -1353,6 +1353,14 @@ public class SettingsActivity extends SettingsDrawerActivity
         }
         super.onActivityResult(requestCode, resultCode, data);
     }
+
+    /**
+     * @return whether or not the activity can be launched from other apps in the pinning screen.
+     */
+    public boolean isLaunchableInTaskModePinned() {
+        return false;
+    }
+
     private boolean isLockTaskModePinned() {
         final ActivityManager activityManager =
             getApplicationContext().getSystemService(ActivityManager.class);


### PR DESCRIPTION
Allow LockScreenPattern to be launched in the pinning screen

If work profile lock is enabled and work app is pinned, users will get a
black/white screen on the phone. That's because Settings is prevented
from other apps launch any pages of Settings in the pinning mode.

In order to launch some pages of Settings from other apps, we add a
condition to the preventive mechanism and allow the activity inherited
from SettingsBaseActivity to override the condition to have the activity
to be launched from other apps in the pinning mode.

Bug: 137015265
Bug: 135604684
Test: manual test
Change-Id: I8070de79a83350d1658efcb19e983669dad0e673
Merged-In: I8070de79a83350d1658efcb19e983669dad0e673
(cherry picked from commit 3f4d3b4ac257451ccc1676f65321dedb2cb1870e)