### PR TITLE
Allows to launch only authenticator owned activities

### DIFF
--- a/src/com/android/settings/accounts/ManageAccountsSettings.java
+++ b/src/com/android/settings/accounts/ManageAccountsSettings.java
@@ -534,14 +534,7 @@ public class ManageAccountsSettings extends AccountPreferenceBase
         ActivityInfo resolvedActivityInfo = resolveInfo.activityInfo;
         ApplicationInfo resolvedAppInfo = resolvedActivityInfo.applicationInfo;
         try {
-            if (resolvedActivityInfo.exported) {
-                if (resolvedActivityInfo.permission == null) {
-                    return true; // exported activity without permission.
-                } else if (pm.checkPermission(resolvedActivityInfo.permission,
-                        authDesc.packageName) == PackageManager.PERMISSION_GRANTED) {
-                    return true;
-                }
-            }
+            // Allows to launch only authenticator owned activities.
             ApplicationInfo authenticatorAppInf = pm.getApplicationInfo(authDesc.packageName, 0);
             return  resolvedAppInfo.uid == authenticatorAppInf.uid;
         } catch (NameNotFoundException e) {


### PR DESCRIPTION
- 3rd party developers can define himself-authenticator
  and use the accountPreferences attribute to load the
  predefined preference UI.
- If a developer defines an action intent to launch the
  other activity in xml and it would return true due
  to the true exported attribute and no permission.
- To avoid launching arbitrary activity. Here allows
  to launch only authenticator owned activities.

Bug: 150946634
Test: make RunSettingsRoboTests -j ROBOTEST_FILTER=com.android.settings.accounts
Test: PoC app
Change-Id: I5ce1a0b3838db7b3fbe48c6ea23d5f093d625cdb
Merged-In: I5ce1a0b3838db7b3fbe48c6ea23d5f093d625cdb
(cherry picked from commit d6d8f988449617d757a5d7439314198d10d6ee78)
(cherry picked from commit 4b6e82fd5d2204cd37eae0d7c7b08f19b96baffe)