### PR TITLE
Prevent using invalid result uri during multi user image change

### DIFF
--- a/src/com/android/settings/users/EditUserPhotoController.java
+++ b/src/com/android/settings/users/EditUserPhotoController.java
@@ -19,6 +19,7 @@ package com.android.settings.users;
 import android.app.Activity;
 import android.app.Fragment;
 import android.content.ClipData;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -37,6 +38,7 @@ import android.os.UserHandle;
 import android.os.UserManager;
 import android.provider.ContactsContract.DisplayPhoto;
 import android.provider.MediaStore;
+import android.util.EventLog;
 import android.support.v4.content.FileProvider;
 import android.util.Log;
 import android.view.Gravity;
@@ -111,6 +113,14 @@ public class EditUserPhotoController {
         }
         final Uri pictureUri = data != null && data.getData() != null
                 ? data.getData() : mTakePictureUri;
+
+        // Check if the result is a content uri
+        if (!ContentResolver.SCHEME_CONTENT.equals(pictureUri.getScheme())) {
+            Log.e(TAG, "Invalid pictureUri scheme: " + pictureUri.getScheme());
+            EventLog.writeEvent(0x534e4554, "172939189", -1, pictureUri.getPath());
+            return false;
+        }
+
         switch (requestCode) {
             case REQUEST_CODE_CROP_PHOTO:
                 onPhotoCropped(pictureUri, true);


### PR DESCRIPTION
Test: manual
Bug: 172939189
Change-Id: I258c305f825da94474c8027828e3b9707b463699
Merged-In: I258c305f825da94474c8027828e3b9707b463699
Merged-In: I3e6f6200e82e86d6a2085652906ad2d0d44814f5
Merged-In: Id2e598878b3250e8b3590905c6def561e2437d55
Merged-In: I15e15ad88b768a5b679de32c5429d921d850a3cb
(cherry picked from commit 6746add669688765a78d98e9a5bbadcaaca5299d)